### PR TITLE
Hotfix for incomplete sitemap URL generation

### DIFF
--- a/next-sitemap.config.cjs
+++ b/next-sitemap.config.cjs
@@ -1,7 +1,7 @@
 const SITE_URL =
-  process.env.NEXT_PUBLIC_SERVER_URL ||
-  process.env.VERCEL_PROJECT_PRODUCTION_URL ||
-  'https://example.com'
+  `https://${process.env.NEXT_PUBLIC_SERVER_URL}` ||
+  `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}` ||
+  'https://www.robeeds.dev'
 
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {


### PR DESCRIPTION
This pull request introduces changes for next-sitemap.config.cjs. 

The constant ```SITE_URL``` now has ```https://``` as a prefix to the environmental variables used. 